### PR TITLE
update version of jgit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 								<artifactItem>
 									<groupId>org.eclipse.jgit</groupId>
 									<artifactId>org.eclipse.jgit</artifactId>
-									<version>3.2.0-SNAPSHOT</version>
+								    <version>3.2.0.201312181205-r</version>
 									<type>jar</type>
 								</artifactItem>
 								<artifactItem>
@@ -43,11 +43,11 @@
 	</build>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.jgit</groupId>
-			<artifactId>org.eclipse.jgit</artifactId>
-			<version>3.2.0-SNAPSHOT</version>
-		</dependency>
+	    <dependency>
+	        <groupId>org.eclipse.jgit</groupId>
+	        <artifactId>org.eclipse.jgit</artifactId>
+	        <version>3.2.0.201312181205-r</version>
+	    </dependency>
 
 		<!-- eXistDB Library -->
 		<dependency>


### PR DESCRIPTION
the -SNAPSHOT version is no longer listed at http://search.maven.org/#search%7Cgav%7C2%7Cg%3A%22org.eclipse.jgit%22%20AND%20a%3A%22org.eclipse.jgit%22